### PR TITLE
Multiple cards: Copyedit

### DIFF
--- a/cards/blunt-cardiac-injury/card.md
+++ b/cards/blunt-cardiac-injury/card.md
@@ -14,15 +14,16 @@ drugs: null
 
 
 
-# Blunt Cardiac Injury
+# Blunt Cardiac Injury (BCI)
 
 *Definition:* Encompasses wide spectrum of clinical injuries, ranging from asymptomatic myocardial bruise to cardiac rupture/death 
 
+No gold standard
 
 **Pearls:**
 
 -   Causes 20% of all deaths due to motor vehicle collisions
--   Most commonly injured chamber = right ventricle (most anterior in chest) 
+-   Most commonly injured chamber: Right ventricle (most anterior in chest) 
 
 **Clinical tips:**
 
@@ -30,9 +31,7 @@ drugs: null
 -   Consider BCI in hemodynamically unstable patients without alternative cause
 -   Troponin I and T lack adequate sensitivity as screening test  
 
-![](image-1.png)
-
-Suggested algorithm for evaluation of blunt cardiac injury, based on available evidence
+Suggested algorithm, based on available evidence:![](image-1.png)
 
 ## References
 

--- a/cards/blunt-cerebrovascular-injury/card.md
+++ b/cards/blunt-cerebrovascular-injury/card.md
@@ -30,7 +30,7 @@ drugs: 'heparin, aspirin'
 **Signs / symptoms of BCVI**
 
 -   Arterial hemorrhage from neck, nose, or mouth
--   Cervical bruit in patients &lt; 50 years old
+-   Cervical bruit in patients &lt;50 years old
 -   Expanding cervical hematoma
 -   Focal neurologic deficit (TIA, hemiparesis, vertebrobasilar sx, Horner’s) 
 -   Neurologic exam incongruous with head CT findings
@@ -39,7 +39,7 @@ drugs: 'heparin, aspirin'
 **Risk factors for BCVI**
 
 -   LeFort II or III facial fracture
--   C-spine fracture patterns: subluxation, fx extending into transverse foramen, any fracture in C1-C3
+-   C-spine fracture patterns: subluxation, fx extending into transverse foramen, fx involving C1-C3
 -   Basilar skull fracture with carotid canal involvement
 -   Petrous bone fracture
 -   Diffuse axonal injury with GCS &lt; 6
@@ -48,23 +48,25 @@ drugs: 'heparin, aspirin'
 
 ## Imaging Choice
 
--   **Gold standard:** Digital subtraction angiography
--   **Accepted first-line imaging:** CT angiography (at least 16-slice scanner)
--   **Alternative imaging:** MRI (does not need contrast); may be less sensitive and specific than CT
+-   **Gold standard**: Digital subtraction angiography
+-   **Accepted first-line imaging**: CT angiography (at least 16-slice scanner)
+-   **Alternative**: MRI (does not need contrast), may be less sensitive and less specific than CT
 -   NOTE: A simple seat-belt sign along the neck does not warrant a CT angiogram. Patients with higher risk findings such as significant pain, tenderness, swelling, and/or a bruit may need imaging.
 
 ## BCVI Grading and Incidence of CVA complication
 
-| Grade | Definition  | CVA Rate: Carotid   | CVA Rate: Vertebral |
-|:-------:|-------------|:-------------:|:--------:|
-| **1**     | Irregularity of vessel wall, or dissection/intramural hematoma with &lt; 25%luminal stenosis                               | 3%            | 6%             |
-| **2**     | Intraluminal thrombus or raised intimal flap is visualized, or dissection/intramural hematoma with ≥ 25% luminal narrowing | 14%           | 38%            |
+| Grade | Definition  | CVA Rate: Carotid   | CVA: Rate Vertebral: |
+|:-------|-------------|:--------------------:|:--------------------:|
+| **1**     | Irregularity of vessel wall, or dissection/intramural hematoma with &lt;25%luminal stenosis                               | 3%            | 6%             |
+| **2**     | Intraluminal thrombus or raised intimal flap is visualized, or dissection/intramural hematoma with ≥25% luminal narrowing | 14%           | 38%            |
 | **3**     | Pseudoaneurysm                                                                                                             | 26%           | 27%            |
 | **4**     | Vessel occlusion                                                                                                           | 50%           | 28%            |
 | **5**     | Vessel transection                                                                                                         | 100%          | 100%           |
 
-- Risk of undiagnosed BVCI: Delayed CVA (occurring hours to 14 years later) 
--   Majority develop CVA symptoms in 10-72 hours
+Risk of undiagnosed BVCI: Delayed CVA
+
+- May occur hours to 14 years later 
+- Majority develop CVA symptoms in 10-72 hours
 
 ## References
 


### PR DESCRIPTION
Blunt cardiac injury: removed = and replaced with :
Blunt cerebrovascular: removed space between > (or <) and the number,
center aligned table columns